### PR TITLE
Update version number being pulled

### DIFF
--- a/tsqllint.rb
+++ b/tsqllint.rb
@@ -5,12 +5,12 @@ class Tsqllint < Formula
   license "MIT"
 
   on_macos do
-      url "https://github.com/tsqllint/tsqllint/releases/download/1.15.1/osx-x64.tgz"
+      url "https://github.com/tsqllint/tsqllint/releases/download/1.15.3/osx-x64.tgz"
       sha256 "4560f4e49fc5cbd8802c75de5540382124f0c9bb1cfed96f18be89d799cf0da0"
   end
 
   on_linux do
-      url "https://github.com/tsqllint/tsqllint/releases/download/1.15.1/linux-x64.tgz"
+      url "https://github.com/tsqllint/tsqllint/releases/download/1.15.3/linux-x64.tgz"
       sha256 "aa0abe7d7b59b0d1116e47c05098b51241e4db1e2dc909d9e3731dfca97f1a48"
   end
 


### PR DESCRIPTION
Bumps the version number used by brew install to the latest release.